### PR TITLE
Locale Aware parsing

### DIFF
--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -22,6 +22,15 @@
 
 namespace Tunings
 {
+    double locale_atof(const char* s)
+    {
+        double result = 0;
+        std::istringstream istr(s);
+        istr.imbue(std::locale("C"));
+        istr >> result;
+        return result;
+    }
+    
     Scale scaleFromStream(std::istream &inf)
     {
         std::string line;
@@ -54,7 +63,7 @@ namespace Tunings
                 if (line.find(".") != std::string::npos)
                 {
                     t.type = Tone::kToneCents;
-                    t.cents = atof(line.c_str());
+                    t.cents = locale_atof(line.c_str());
                 }
                 else
                 {
@@ -151,6 +160,7 @@ namespace Tunings
     Scale evenDivisionOfSpanByM( int Span, int M )
     {
         std::ostringstream oss;
+        oss.imbue( std::locale( "C" ) );
         oss << "! Automatically generated ED" << Span << "-" << M << " scale\n";
         oss << "Automatically generated ED" << Span << "-" << M << " scale\n";
         oss << M << "\n";
@@ -216,7 +226,7 @@ namespace Tunings
             }
             
             int i = std::atoi(line.c_str());
-            float v = std::atof(line.c_str());
+            float v = locale_atof(line.c_str());
             
             switch (state)
             {

--- a/tests/alltests.cpp
+++ b/tests/alltests.cpp
@@ -216,6 +216,39 @@ TEST_CASE( "Internal Constraints between Measures" )
                 }
             }
     }
+
+    SECTION( "Test All Constraints SCL and KBM in Spain" )
+    {
+        bool spainAvailable = true;
+        try {
+            std::locale( "es_ES" );
+        }
+        catch( std::exception &e )
+        {
+            INFO( "es_ES locale not availale on this machine; skpping test" );
+            spainAvailable = false;
+        }
+
+        if( spainAvailable )
+        {
+            std::locale::global( std::locale( "es_ES" ) );
+            for( auto fs: testSCLs() )
+                for( auto fk : testKBMs() )
+                {
+                    INFO( "Testing Constraints with " << fs << " " << fk );
+                    auto s = Tunings::readSCLFile(testFile(fs));
+                    auto k = Tunings::readKBMFile(testFile(fk));
+                    Tunings::Tuning t(s,k);
+                    
+                    for( int i=0; i<127; ++i )
+                    {
+                        REQUIRE( t.frequencyForMidiNote(i) == t.frequencyForMidiNoteScaledByMidi0(i) * Tunings::MIDI_0_FREQ );
+                        REQUIRE( t.frequencyForMidiNoteScaledByMidi0(i) == pow( 2.0, t.logScaledFrequencyForMidiNote(i) ) );
+                    }
+                }
+            std::locale::global( std::locale( "" ) );
+        }
+    }
 }
 
 TEST_CASE( "Several Sample Scales" )


### PR DESCRIPTION
atof("1.23") doesn't work in spain where they expect "1,23" so
use locale "C" in a few critical places, and add a regtest which
if my machine has spain, tests it in spain too.