### PR TITLE
Inline to avoid symbol collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,11 @@ endif
 
 TUNING=include/Tunings.h include/TuningsImpl.h
 
-all:	$(BLD)/alltests $(BLD)/showmapping
+all:	$(BLD)/alltests $(BLD)/showmapping $(BLD)/symbolcheck
 
 runtests:	all
+	@$(BLD)/symbolcheck
+
 	@$(BLD)/alltests
 
 	@LANG=`locale -a | grep es_ES | grep -v "\." | head -1` $(BLD)/alltests
@@ -35,6 +37,11 @@ runtests:	all
 	@LANG=`locale -a | grep zh_CN | head -1` $(BLD)/alltests
 	@LANG=`locale -a | grep MAKE_SURE_NULL_IS_OK | grep -v "\." | head -1` $(BLD)/alltests	
 
+$(BLD)/symbolcheck:	tests/symbolcheck1.cpp tests/symbolcheck2.cpp $(TUNING) $(BLD)
+	@echo If this build fails, you forgot an inline
+	$(CC) $(CCFLAGS) -c tests/symbolcheck1.cpp -o $(BLD)/symbolcheck1.o
+	$(CC) $(CCFLAGS) -c tests/symbolcheck2.cpp -o $(BLD)/symbolcheck2.o
+	$(CC) $(CCFLAGS) $(BLD)/symbolcheck1.o $(BLD)/symbolcheck2.o -o $(BLD)/symbolcheck
 
 $(BLD)/alltests:	tests/alltests.cpp $(TUNING) $(BLD)
 	$(CC) $(CCFLAGS) $< -o $@

--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -22,7 +22,7 @@
 
 namespace Tunings
 {
-    double locale_atof(const char* s)
+    inline double locale_atof(const char* s)
     {
         double result = 0;
         std::istringstream istr(s);
@@ -31,7 +31,7 @@ namespace Tunings
         return result;
     }
     
-    Scale scaleFromStream(std::istream &inf)
+    inline Scale scaleFromStream(std::istream &inf)
     {
         std::string line;
         const int read_header = 0, read_count = 1, read_note = 2, trailing = 3;
@@ -111,7 +111,7 @@ namespace Tunings
         return res;
     }
 
-    Scale readSCLFile(std::string fname)
+    inline Scale readSCLFile(std::string fname)
     {
         std::ifstream inf;
         inf.open(fname);
@@ -126,7 +126,7 @@ namespace Tunings
         return res;
     }
 
-    Scale parseSCLData(const std::string &d)
+    inline Scale parseSCLData(const std::string &d)
     {
         std::istringstream iss(d);
         auto res = scaleFromStream(iss);
@@ -134,7 +134,7 @@ namespace Tunings
         return res;
     }
 
-    Scale evenTemperament12NoteScale()
+    inline Scale evenTemperament12NoteScale()
     {
         std::string data = R"SCL(! even.scl
 !
@@ -157,7 +157,7 @@ namespace Tunings
         return parseSCLData(data);
     }
 
-    Scale evenDivisionOfSpanByM( int Span, int M )
+    inline Scale evenDivisionOfSpanByM( int Span, int M )
     {
         std::ostringstream oss;
         oss.imbue( std::locale( "C" ) );
@@ -176,7 +176,7 @@ namespace Tunings
         return parseSCLData( oss.str() );
     }
     
-    KeyboardMapping keyboardMappingFromStream(std::istream &inf)
+    inline KeyboardMapping keyboardMappingFromStream(std::istream &inf)
     {
         std::string line;
         
@@ -280,7 +280,7 @@ namespace Tunings
         return res;
     }
 
-    KeyboardMapping readKBMFile(std::string fname)
+    inline KeyboardMapping readKBMFile(std::string fname)
     {
         std::ifstream inf;
         inf.open(fname);
@@ -295,7 +295,7 @@ namespace Tunings
         return res;
     }
     
-    KeyboardMapping parseKBMData(const std::string &d)
+    inline KeyboardMapping parseKBMData(const std::string &d)
     {
         std::istringstream iss(d);
         auto res = keyboardMappingFromStream(iss);
@@ -303,11 +303,11 @@ namespace Tunings
         return res;
     }
     
-    Tuning::Tuning() : Tuning( evenTemperament12NoteScale(), KeyboardMapping() ) { }
-    Tuning::Tuning(const Scale &s ) : Tuning( s, KeyboardMapping() ) {}
-    Tuning::Tuning(const KeyboardMapping &k ) : Tuning( evenTemperament12NoteScale(), k ) {}
+    inline Tuning::Tuning() : Tuning( evenTemperament12NoteScale(), KeyboardMapping() ) { }
+    inline Tuning::Tuning(const Scale &s ) : Tuning( s, KeyboardMapping() ) {}
+    inline Tuning::Tuning(const KeyboardMapping &k ) : Tuning( evenTemperament12NoteScale(), k ) {}
     
-    Tuning::Tuning(const Scale& s, const KeyboardMapping &k)
+    inline Tuning::Tuning(const Scale& s, const KeyboardMapping &k)
     {
         scale = s;
         keyboardMapping = k;
@@ -451,27 +451,27 @@ namespace Tunings
         }
     }
 
-    double Tuning::frequencyForMidiNote( int mn ) const {
+    inline double Tuning::frequencyForMidiNote( int mn ) const {
         auto mni = std::min( std::max( 0, mn + 256 ), N-1 );
         return ptable[ mni ] * MIDI_0_FREQ;
     }
 
-    double Tuning::frequencyForMidiNoteScaledByMidi0( int mn ) const {
+    inline double Tuning::frequencyForMidiNoteScaledByMidi0( int mn ) const {
         auto mni = std::min( std::max( 0, mn + 256 ), N-1 );
         return ptable[ mni ];
     }
 
-    double Tuning::logScaledFrequencyForMidiNote( int mn ) const {
+    inline double Tuning::logScaledFrequencyForMidiNote( int mn ) const {
         auto mni = std::min( std::max( 0, mn + 256 ), N-1 );
         return lptable[ mni ];
     }
 
-    KeyboardMapping tuneA69To(double freq)
+    inline KeyboardMapping tuneA69To(double freq)
     {
         return tuneNoteTo( 69, freq );
     }
 
-    KeyboardMapping tuneNoteTo( int midiNote, double freq )
+    inline KeyboardMapping tuneNoteTo( int midiNote, double freq )
     {
         KeyboardMapping k;
         k.tuningConstantNote = midiNote;

--- a/tests/symbolcheck1.cpp
+++ b/tests/symbolcheck1.cpp
@@ -1,0 +1,11 @@
+/*
+** Make sure we don't have duplicated symbols by compiling a pair of objects
+** and linking them
+*/
+
+#include "Tunings.h"
+
+double symbolcheck1() {
+   auto k = Tunings::tuneNoteTo( 60, 100 );
+   return k.tuningFrequency;
+}

--- a/tests/symbolcheck2.cpp
+++ b/tests/symbolcheck2.cpp
@@ -1,0 +1,19 @@
+/*
+** Make sure we don't have duplicated symbols by compiling a pair of objects
+** and linking them
+*/
+
+#include <iostream>
+#include <iomanip>
+#include "Tunings.h"
+
+double symbolcheck2() {
+   auto k = Tunings::tuneNoteTo( 60, 200 );
+   return k.tuningFrequency;
+}
+
+int main( int argc, char **argv )
+{
+   extern double symbolcheck1();
+   std::cout << "100 and 200 are " << symbolcheck1() << " and " << symbolcheck2 () << std::endl;
+}


### PR DESCRIPTION
My library had not put inline in the right place. Thus when I linked
I got symbol collisions. Fix that up and add a test to make sure it
stays fixed.