### PR TITLE
Throw on Tuning when Mapping bigger than Scale

### DIFF
--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -374,7 +374,13 @@ namespace Tunings
 
         if( s.count <= 0 )
             throw TuningError( "Unable to tune to a scale with no notes. Your scale provided " + std::to_string( s.count ) + " notes." );
-            
+
+        // From the KBM Spec: When not all scale degrees need to be mapped, the size of the map can be smaller than the size of the scale.
+        if( k.octaveDegrees > s.count )
+        {
+            throw TuningError( "Unable to apply mapping of size " + std::to_string( k.octaveDegrees ) +
+                                " to smaller scale of size " + std::to_string(s.count));
+        }
         
         double pitches[N];
 

--- a/tests/alltests.cpp
+++ b/tests/alltests.cpp
@@ -218,6 +218,9 @@ TEST_CASE( "Internal Constraints between Measures" )
                 INFO( "Testing Constraints with " << fs << " " << fk );
                 auto s = Tunings::readSCLFile(testFile(fs));
                 auto k = Tunings::readKBMFile(testFile(fk));
+
+                if( k.octaveDegrees > s.count ) continue; // don't test this verion; trap it below as an error case
+
                 Tunings::Tuning t(s,k);
                 
                 for( int i=0; i<127; ++i )
@@ -251,6 +254,9 @@ TEST_CASE( "Internal Constraints between Measures" )
                     INFO( "Testing Constraints with " << fs << " " << fk );
                     auto s = Tunings::readSCLFile(testFile(fs));
                     auto k = Tunings::readKBMFile(testFile(fk));
+
+                    if( k.octaveDegrees > s.count ) continue; // don't test this verion; trap it below as an error case
+
                     Tunings::Tuning t(s,k);
                     
                     for( int i=0; i<127; ++i )
@@ -556,6 +562,23 @@ TEST_CASE( "Exceptions and Bad Files" )
         {
             REQUIRE( std::string( e.what() ) == "Unable to open file 'MISSING'" );
         }
+    }
+
+    SECTION( "Mappings bigger than Scales Throw" )
+    {
+        bool testedAtLeastOne = false;
+        for (auto fs: testSCLs())
+            for (auto fk : testKBMs()) {
+                INFO("Looking for mis-sized pairs " << fs << " " << fk);
+                auto s = Tunings::readSCLFile(testFile(fs));
+                auto k = Tunings::readKBMFile(testFile(fk));
+
+                if (k.octaveDegrees <= s.count) continue;
+
+                testedAtLeastOne = true;
+                REQUIRE_THROWS_AS(Tunings::Tuning(s, k), Tunings::TuningError);
+            }
+        REQUIRE( testedAtLeastOne );
     }
 
     SECTION( "Bad SCL" )


### PR DESCRIPTION
The KBM spec says the octaveDegree has to be less than or
equal to the scale size. We neither required that in our
API nor tested it correctly in our test. Thanks to discord
user chinenual for flagging this to us.