### PR TITLE
Add an improved 'skipped note' API

### DIFF
--- a/include/Tunings.h
+++ b/include/Tunings.h
@@ -229,6 +229,14 @@ namespace Tunings
         Tuning( const KeyboardMapping &k );
         Tuning( const Scale &s, const KeyboardMapping &k );
 
+        /*
+         * Skipped notes can either have nonsense values or interpolated values.
+         * The old API made the bad choice to have nonsense values which we retain
+         * for compatability, but this method will return a new tuning with correctly
+         * interpolated skipped notes.
+         */
+        Tuning withSkippedNotesInterpolated() const;
+
         /**
          * These three related functions provide you the information you
          * need to use this tuning.
@@ -260,6 +268,7 @@ namespace Tunings
         double frequencyForMidiNoteScaledByMidi0( int mn ) const;
         double logScaledFrequencyForMidiNote( int mn ) const;
         int scalePositionForMidiNote( int mn ) const;
+        bool isMidiNoteUnmapped(int mn) const;
 
         // For convenience, the scale and mapping used to construct this are kept as public copies
         Scale scale;

--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -622,6 +622,30 @@ namespace Tunings
         return scalepositiontable[ mni ];
     }
 
+    inline bool Tuning::isMidiNoteUnmapped(int mn) const {
+        auto mni = std::min( std::max( 0, mn + 256 ), N-1 );
+        return scalepositiontable[mni] >= 0;
+    }
+
+    inline Tuning Tuning::withSkippedNotesInterpolated() const {
+        Tuning res = *this;
+        for (int i=1; i<N-1; ++i)
+        {
+            if (scalepositiontable[i] < 0)
+            {
+                int nxt = i+1;
+                int prv = i-1;
+                while( prv >= 0 && scalepositiontable[prv] < 0 ) prv--;
+                while( nxt < N && scalepositiontable[nxt] < 0 ) nxt++;
+                float dist = nxt - prv;
+                float frac = ( i - prv ) / dist;
+                res.lptable[i] = (1.0-frac) * lptable[prv] + frac * lptable[nxt];
+                res.ptable[i] = pow( 2.0, res.lptable[i] );
+            }
+        }
+        return res;
+    }
+
     inline KeyboardMapping::KeyboardMapping()
         : count(0),
           firstMidi(0),


### PR DESCRIPTION
Improved in two regards

1. All scales can tell you if a midi note is skipped
2. Tunings can do a reasonable log interpolation for skipped notes
   so the tuning table isn't blank.