### PR TITLE
Fixes to unmapped pish

### DIFF
--- a/include/Tunings.h
+++ b/include/Tunings.h
@@ -262,7 +262,7 @@ class Tuning
     double frequencyForMidiNoteScaledByMidi0(int mn) const;
     double logScaledFrequencyForMidiNote(int mn) const;
     int scalePositionForMidiNote(int mn) const;
-    bool isMidiNoteUnmapped(int mn) const;
+    bool isMidiNoteMapped(int mn) const;
 
     // For convenience, the scale and mapping used to construct this are kept as public copies
     Scale scale;

--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -642,7 +642,7 @@ inline int Tuning::scalePositionForMidiNote(int mn) const
     return scalepositiontable[mni];
 }
 
-inline bool Tuning::isMidiNoteUnmapped(int mn) const
+inline bool Tuning::isMidiNoteMapped(int mn) const
 {
     auto mni = std::min(std::max(0, mn + 256), N - 1);
     return scalepositiontable[mni] >= 0;

--- a/tests/alltests.cpp
+++ b/tests/alltests.cpp
@@ -1026,13 +1026,36 @@ TEST_CASE("KBM Constructor RawText")
 
 TEST_CASE("Skipped Note API")
 {
+    SECTION("Default Tuning skips Nothing")
+    {
+        auto t = Tunings::Tuning();
+        for (int i = 0; i < 128; ++i)
+            REQUIRE(t.isMidiNoteMapped(i));
+    }
+
+    SECTION("SCL-only Tuning skips Nothing")
+    {
+        auto s = Tunings::readSCLFile(testFile("12-intune.scl"));
+        auto t = Tunings::Tuning(s);
+        for (int i = 0; i < 128; ++i)
+            REQUIRE(t.isMidiNoteMapped(i));
+    }
+
+    SECTION("KBM-only Tuning absent skips skips Nothing")
+    {
+        auto k = Tunings::readKBMFile(testFile("empty-note69.kbm"));
+        auto t = Tunings::Tuning(k);
+        for (int i = 0; i < 128; ++i)
+            REQUIRE(t.isMidiNoteMapped(i));
+    }
+
     SECTION("Fully Mapped")
     {
         auto s = Tunings::readSCLFile(testFile("12-intune.scl"));
         auto k = Tunings::readKBMFile(testFile("empty-note69.kbm"));
         auto t = Tunings::Tuning(s, k);
         for (int i = 0; i < 128; ++i)
-            REQUIRE(t.isMidiNoteUnmapped(i));
+            REQUIRE(t.isMidiNoteMapped(i));
     }
 
     SECTION("Gaps in the Maps")
@@ -1045,7 +1068,20 @@ TEST_CASE("Skipped Note API")
             int i = k % 12;
             bool isOn = i == 0 || i == 2 || i == 4 || i == 5 || i == 7 || i == 9 || i == 11;
             INFO(k << " scpos=" << i << " isOn = " << isOn);
-            REQUIRE(t.isMidiNoteUnmapped(i) == isOn);
+            REQUIRE(t.isMidiNoteMapped(i) == isOn);
+        }
+    }
+
+    SECTION("Gaps in the Maps KBM Only")
+    {
+        auto k = Tunings::readKBMFile(testFile("mapping-whitekeys-a440.kbm"));
+        auto t = Tunings::Tuning(k);
+        for (int k = 0; k < 128; ++k)
+        {
+            int i = k % 12;
+            bool isOn = i == 0 || i == 2 || i == 4 || i == 5 || i == 7 || i == 9 || i == 11;
+            INFO(k << " scpos=" << i << " isOn = " << isOn);
+            REQUIRE(t.isMidiNoteMapped(i) == isOn);
         }
     }
 
@@ -1078,7 +1114,7 @@ TEST_CASE("Skipped Note API")
             INFO("Testing monotnicity note " << k);
             int i = k % 12;
             bool isOn = i == 0 || i == 2 || i == 4 || i == 5 || i == 7 || i == 9 || i == 11;
-            REQUIRE(t.isMidiNoteUnmapped(i) == isOn);
+            REQUIRE(t.isMidiNoteMapped(i) == isOn);
 
             REQUIRE(t.logScaledFrequencyForMidiNote(k) > t.logScaledFrequencyForMidiNote(k - 1));
             REQUIRE(t.frequencyForMidiNote(k) > t.frequencyForMidiNote(k - 1));


### PR DESCRIPTION
1. The name was backwards. We are testing if a note is mapped
2. Add a few more tests which are a bit more exhaustive