### PR TITLE
Add missing cstring include

### DIFF
--- a/commands/parsecheck.cpp
+++ b/commands/parsecheck.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <iomanip>
 #include "Tunings.h"
 #include "TuningsImpl.h"


### PR DESCRIPTION
commands/parsecheck.cpp:
Add a missing include of 'cstring' that would fail the builds using gcc >= 11.1.0.

```
/usr/bin/c++  -I/build/tuning-library/src/tuning-library-1.1.0/include -D_FORTIFY_SOURCE=2 -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -std=gnu++14 -MD -MT CMakeFiles/tuning-library-symbolcheck.dir/tests/symbolcheck1.cpp.o -MF CMakeFiles/tuning-library-symbolcheck.dir/tests/symbolcheck1.cpp.o.d -o CMakeFiles/tunin
g-library-symbolcheck.dir/tests/symbolcheck1.cpp.o -c /build/tuning-library/src/tuning-library-1.1.0/tests/symbolcheck1.cpp
/build/tuning-library/src/tuning-library-1.1.0/commands/parsecheck.cpp: In function ‘int main(int, char**)’:
/build/tuning-library/src/tuning-library-1.1.0/commands/parsecheck.cpp:11:17: error: ‘strstr’ was not declared in this scope
   11 |             if (strstr(argv[i], ".scl")) {
      |                 ^~~~~~
/build/tuning-library/src/tuning-library-1.1.0/commands/parsecheck.cpp:4:1: note: ‘strstr’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
    3 | #include "TuningsImpl.h"
  +++ |+#include <cstring>
    4 |
make[2]: *** [CMakeFiles/parsecheck.dir/build.make:76: CMakeFiles/parsecheck.dir/commands/parsecheck.cpp.o] Error 1
make[2]: Leaving directory '/build/tuning-library/src/tuning-library-1.1.0/build'
make[1]: *** [CMakeFiles/Makefile2:169: CMakeFiles/parsecheck.dir/all] Error 2
```