### PR TITLE
Only build tests by default when the top-level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,40 +6,49 @@ set(CMAKE_CXX_STANDARD 14)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE include)
 
-add_executable(tuning-library-symbolcheck)
-target_link_libraries(tuning-library-symbolcheck PRIVATE ${PROJECT_NAME})
-target_sources(tuning-library-symbolcheck PRIVATE
-        tests/symbolcheck1.cpp
-        tests/symbolcheck2.cpp)
-
-
-add_executable(tuning-library-tests)
-target_include_directories(tuning-library-tests PRIVATE libs/catch2)
-target_link_libraries(tuning-library-tests PRIVATE ${PROJECT_NAME})
-target_sources(tuning-library-tests PRIVATE
-        tests/alltests.cpp)
-
-add_executable(showmapping commands/showmapping.cpp)
-target_link_libraries(showmapping ${PROJECT_NAME})
-
-add_executable(parsecheck commands/parsecheck.cpp)
-target_link_libraries(parsecheck ${PROJECT_NAME})
-
-if (WIN32)
-    add_custom_target(run-all-tests
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            COMMAND $<TARGET_FILE:tuning-library-symbolcheck>
-            COMMAND $<TARGET_FILE:tuning-library-tests>
-        )
+get_directory_property(parent_dir PARENT_DIRECTORY)
+if("${parent_dir}" STREQUAL "")
+    set(is_toplevel 1)
 else()
-    add_custom_target(run-all-tests
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            COMMAND $<TARGET_FILE:tuning-library-symbolcheck>
-            COMMAND $<TARGET_FILE:tuning-library-tests>
-            COMMAND LANG=es_ES  $<TARGET_FILE:tuning-library-tests>
-            COMMAND LANG=fr_FR  $<TARGET_FILE:tuning-library-tests>
-            COMMAND LANG=zh_CN  $<TARGET_FILE:tuning-library-tests>
-            COMMAND LANG=  $<TARGET_FILE:tuning-library-tests>
-        )
+    set(is_toplevel 0)
 endif()
-add_dependencies(run-all-tests tuning-library-tests tuning-library-symbolcheck)
+option(TUNING_LIBRARY_BUILD_TESTS "Add targets for building and running tests" ${is_toplevel})
+
+if(TUNING_LIBRARY_BUILD_TESTS)
+    add_executable(tuning-library-symbolcheck)
+    target_link_libraries(tuning-library-symbolcheck PRIVATE ${PROJECT_NAME})
+    target_sources(tuning-library-symbolcheck PRIVATE
+            tests/symbolcheck1.cpp
+            tests/symbolcheck2.cpp)
+
+    add_executable(tuning-library-tests)
+    target_include_directories(tuning-library-tests PRIVATE libs/catch2)
+    target_link_libraries(tuning-library-tests PRIVATE ${PROJECT_NAME})
+    target_sources(tuning-library-tests PRIVATE
+            tests/alltests.cpp)
+
+    add_executable(showmapping commands/showmapping.cpp)
+    target_link_libraries(showmapping ${PROJECT_NAME})
+
+    add_executable(parsecheck commands/parsecheck.cpp)
+    target_link_libraries(parsecheck ${PROJECT_NAME})
+
+    if (WIN32)
+        add_custom_target(run-all-tests
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                COMMAND $<TARGET_FILE:tuning-library-symbolcheck>
+                COMMAND $<TARGET_FILE:tuning-library-tests>
+            )
+    else()
+        add_custom_target(run-all-tests
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                COMMAND $<TARGET_FILE:tuning-library-symbolcheck>
+                COMMAND $<TARGET_FILE:tuning-library-tests>
+                COMMAND LANG=es_ES  $<TARGET_FILE:tuning-library-tests>
+                COMMAND LANG=fr_FR  $<TARGET_FILE:tuning-library-tests>
+                COMMAND LANG=zh_CN  $<TARGET_FILE:tuning-library-tests>
+                COMMAND LANG=  $<TARGET_FILE:tuning-library-tests>
+            )
+    endif()
+    add_dependencies(run-all-tests tuning-library-tests tuning-library-symbolcheck)
+endif()


### PR DESCRIPTION
Removes these targets by default in Surge and Bespoke:
![image](https://user-images.githubusercontent.com/304760/137583961-4dad5c60-c8fb-4dc3-bb40-aa564aabdbb9.png)
On CLion in particular, this increases the odds that the top-level app (e.g. `BespokeSynth`) becomes the default run target (instead of `parsecheck`).

---

This adds a build option `TUNING_LIBRARY_BUILD_TESTS`, which defaults to
`ON` when the tuning library is the top-level project and to `OFF` when
`add_subdirectory`'d from elsewhere, reducing IDE clutter in projects
that use this library.