### PR TITLE
Support end-of-line comments in scl files

### DIFF
--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -70,11 +70,15 @@ inline double locale_atof(const char *s)
     return result;
 }
 
-inline Tone toneFromString(const std::string &line, int lineno)
+inline Tone toneFromString(const std::string &fullLine, int lineno)
 {
     Tone t;
-    t.stringRep = line;
+    t.stringRep = fullLine;
     t.lineno = lineno;
+
+    // Allow end-of-line comments, e.g. "555/524 ! c# 138.75 Hz"
+    std::string line = fullLine.substr(0, fullLine.find("!", 0));
+
     if (line.find('.') != std::string::npos)
     {
         t.type = Tone::kToneCents;

--- a/tests/alltests.cpp
+++ b/tests/alltests.cpp
@@ -820,6 +820,12 @@ TEST_CASE("Tone API")
         REQUIRE(t3.ratio_d == 1);
         REQUIRE(t3.ratio_n == 3);
         REQUIRE(t3.floatValue == Approx(log(3.0 / 1.0) / log(2.0) + 1.0).margin(1e-6));
+
+        auto t4 = Tunings::toneFromString("555/524 ! c# 138.75 Hz");
+        REQUIRE(t4.type == Tunings::Tone::kToneRatio);
+        REQUIRE(t4.ratio_d == 524);
+        REQUIRE(t4.ratio_n == 555);
+        REQUIRE(t4.floatValue == Approx(log(555.0 / 524.0) / log(2.0) + 1.0).margin(1e-6));
     }
 
     SECTION("Ridiculously Long Fraction Tones")


### PR DESCRIPTION
I ran into some scl files which use end-of-line comments on each ratio, for example septenariusGG49.scl from the Scala scale archive:
```
! septenariusGG49.scl
Sparschuh's version @ middle-c'=262Hz or a'=440Hz
12
!absolute pitches relativ to c=131 Hz
555/524 ! c# 138.75 Hz
147/131 ! d
156/131 ! eb
165/131 ! e
175/131 ! f
185/131 ! f#
196/131 ! g
208/131 ! g#
220/131 ! a 440Hz/2
234/131 ! bb
247/131 ! b
2/1
```
At the moment a `.` in the comment causes the line to be interpreted as a cent value, which can give unexpected results. For example for septenariusGG49.scl, the line `555/524 ! c# 138.75 Hz` is currently given a cent value of `555.0` - I've attached a screenshot from the Surge tuning editor:
<img width="1256" alt="Screenshot 2024-12-29 at 22 56 41" src="https://github.com/user-attachments/assets/0164e5a4-f1da-4172-b9d1-83950d89f88e" />

The scl files in the Scala scale archive which give unexpected results for this reason are:
```
septenariusGG49.scl
sparschuh-442widefrench5th.scl
sparschuh-eleven_eyes.scl
sparschuh-eqbeat-fac_ceg.scl
sparschuh-gothic440.scl
sparschuh-oldpiano.scl
sparschuh-squiggle_harpsichord.scl
sparschuh-stanhope.scl
sparschuh-wohltemperiert.scl
sparschuh_53in13lim.scl
sparschuh_53tone5limit.scl
sparschuh_bach_cup.scl
sparschuh_dyadrat53.scl
```

There's also some cases from the tuning mailing list, for example [here](https://yahootuninggroupsultimatebackup.github.io/tuning/topicId_49980.html#50138), [here](https://yahootuninggroupsultimatebackup.github.io/tuning/topicId_7202.html#7279), and [here](https://yahootuninggroupsultimatebackup.github.io/tuning/topicId_50719.html#50722).

I made a local tuning-library change to handle end-of-line comments so I thought I'd make a PR with it in case it's useful.