### PR TITLE
Support REFERENCE_PITCH octave

### DIFF
--- a/commands/parsecheck.cpp
+++ b/commands/parsecheck.cpp
@@ -5,19 +5,23 @@
 
 int main(int argc, char **argv)
 {
-    for (int i=1; i<argc; ++i)
+    for (int i = 1; i < argc; ++i)
     {
         std::cout << std::setw(50) << argv[i];
-        try {
-            if (strstr(argv[i], ".scl")) {
+        try
+        {
+            if (strstr(argv[i], ".scl"))
+            {
                 Tunings::readSCLFile(argv[i]);
                 std::cout << " PASSED";
             }
-            else if (strstr(argv[i], ".kbm")) {
+            else if (strstr(argv[i], ".kbm"))
+            {
                 Tunings::readKBMFile(argv[i]);
                 std::cout << " PASSED";
             }
-            else if (strstr(argv[i], ".ascl")) {
+            else if (strstr(argv[i], ".ascl"))
+            {
                 Tunings::readASCLFile(argv[i]);
                 std::cout << " PASSED";
             }
@@ -25,8 +29,8 @@ int main(int argc, char **argv)
             {
                 std::cout << " SKIPPED";
             }
-
-        } catch(Tunings::TuningError &t)
+        }
+        catch (Tunings::TuningError &t)
         {
             std::cout << " FAILED : " << t.what();
         }

--- a/commands/showmapping.cpp
+++ b/commands/showmapping.cpp
@@ -36,22 +36,25 @@ int main(int argc, char **argv)
             t = Tuning(s, k);
         }
 
-        std::cout << "Note ,"
-                  << " Freq (Hz) , "
-                  << "  ScaledFrq , "
-                  << " logScaled " << std::endl;
+        std::cout << std::setw(4) << "Note," << std::setw(18) << "Freq (Hz)," << std::setw(18)
+                  << "ScaledFrq," << std::setw(18) << "logScaled," << std::setw(6) << "Pos,"
+                  << " Name" << std::endl;
 
         for (int i = 0; i < 128; ++i)
         {
             if (t.isMidiNoteMapped(i))
             {
-                std::cout << std::setw(4) << i << ", " << std::setw(10) << std::setprecision(10)
-                          << std::fixed << t.frequencyForMidiNote(i) << ", " << std::setw(10)
+                std::cout << std::setw(4) << i << ", " << std::setw(16) << std::setprecision(10)
+                          << std::fixed << t.frequencyForMidiNote(i) << ", " << std::setw(16)
                           << std::setprecision(10) << std::fixed
-                          << t.frequencyForMidiNoteScaledByMidi0(i) << ", " << std::setw(10)
+                          << t.frequencyForMidiNoteScaledByMidi0(i) << ", " << std::setw(16)
                           << std::setprecision(10) << std::fixed
-                          << t.logScaledFrequencyForMidiNote(i) << ", "
-                    << t.scalePositionForMidiNote(i) << std::endl;
+                          << t.logScaledFrequencyForMidiNote(i) << ", " << std::setw(4)
+                          << t.scalePositionForMidiNote(i) << ", "
+                          << (t.notationMapping.count
+                                  ? t.noteNameForScalePosition(t.scalePositionForMidiNote(i))
+                                  : "N/A")
+                          << std::endl;
             }
             else
             {

--- a/include/Tunings.h
+++ b/include/Tunings.h
@@ -112,6 +112,7 @@ struct KeyboardMapping
     int middleNote;
     int tuningConstantNote;
     double tuningFrequency, tuningPitch; // pitch = frequency / MIDI_0_FREQ
+    int tuningOctave; // octave of the tuning reference, only used in Tuning::midiNoteForNoteName()
     int octaveDegrees;
     std::vector<int> keys; // rather than an 'x' we use a '-1' for skipped keys
 

--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -882,10 +882,9 @@ inline int Tuning::midiNoteForNoteName(std::string noteName, int octave) const
         throw TuningError(s);
     }
     int scalePosition = positive_mod(it - notationMapping.names.begin() + 1, notationMapping.count);
-    int referencePitchOctave = ceil((keyboardMapping.middleNote - 21) / 12);
     return std::min(
         std::max(0, scalePosition + keyboardMapping.middleNote +
-                        keyboardMapping.octaveDegrees * (octave - referencePitchOctave)),
+                        keyboardMapping.octaveDegrees * (octave - keyboardMapping.tuningOctave)),
         N - 1);
 }
 
@@ -1041,6 +1040,7 @@ inline AbletonScale readASCLStream(std::istream &inf)
                 as.keyboardMapping.tuningPitch = as.keyboardMapping.tuningFrequency / MIDI_0_FREQ;
                 as.keyboardMapping.tuningConstantNote =
                     as.midiNoteForScalePosition(as.referencePitchIndex);
+                as.keyboardMapping.tuningOctave = as.referencePitchOctave;
                 as.keyboardMapping.middleNote = as.midiNoteForScalePosition(0);
             }
             else

--- a/include/TuningsImpl.h
+++ b/include/TuningsImpl.h
@@ -922,8 +922,8 @@ inline Tuning Tuning::withSkippedNotesInterpolated() const
 
 inline KeyboardMapping::KeyboardMapping()
     : count(0), firstMidi(0), lastMidi(127), middleNote(60), tuningConstantNote(60),
-      tuningFrequency(MIDI_0_FREQ * 32.0), tuningPitch(32.0), octaveDegrees(0), rawText(""),
-      name("")
+      tuningFrequency(MIDI_0_FREQ * 32.0), tuningPitch(32.0), tuningOctave(4), octaveDegrees(0),
+      rawText(""), name("")
 {
     std::ostringstream oss;
     oss.imbue(std::locale("C"));

--- a/tests/alltests.cpp
+++ b/tests/alltests.cpp
@@ -1404,6 +1404,10 @@ TEST_CASE("Loading Ableton scales")
         REQUIRE(t.noteNameForScalePosition(0) == "C");
         REQUIRE(t.noteNameForScalePosition(4) == "E1/2♭");
         REQUIRE(t.noteNameForScalePosition(4 + t.scale.count) == "E1/2♭");
+
+        auto s2 = Tunings::readASCLFile(testFile("rast6.ascl"));
+        Tunings::Tuning t2(s2);
+        REQUIRE(t2.midiNoteForNoteName("C", 4) == 60);
     }
 
     SECTION("Tuning read without ASCL")

--- a/tests/data/rast6.ascl
+++ b/tests/data/rast6.ascl
@@ -48,7 +48,7 @@ A version of Maqam Rast with a wide range of choices of pitch variants. Because 
 1200.
 !
 ! @ABL NOTE_NAMES "C " "D♭ " "D " "E♭ " "E1/2♭-a- " "E1/2♭-b- " "E1/2♭-c- " "E1/2♭-d- " "E " "F " "F♯ " "G " "A♭ " "A1/2♭ " "A " "B♭-a- " "B♭-b- " "B1/2♭-a- " "B1/2♭-b- " "B♮/C♭ "
-! @ABL REFERENCE_PITCH 3 0 261.6256
+! @ABL REFERENCE_PITCH 4 0 261.6256
 ! @ABL NOTE_RANGE_BY_INDEX 0 0 6 7
 ! @ABL SOURCE Inside Arabic Music, Chapter 11 (description of Tuning System); Ch 14-16 (descriptions of Ajnas); Ch 24 (Sayr diagrams of Maqam Rast and Maqam Suznak)
 ! @ABL LINK https://www.ableton.com/learn-more/tuning-systems/rast-6


### PR DESCRIPTION
This PR adds support for the octave argument of the ASCL `REFERENCE_PITCH` declaration.

Before this PR, the octave definition of the reference pitch had no effect - the `Tuning::midiNoteForNoteName()` always assumed a fixed octave for the reference pitch.

I added a test to demonstrate the difference.

I also modified `showmapping` to display the note names when available. The display now looks like:
```
$ ./build/showmapping tests/data/maqamat.ascl 
Note,        Freq (Hz),        ScaledFrq,        logScaled,  Pos, Name
   0,    19.4454390617,     2.3784145455,     1.2500001913,    4, E♭/D♯
   1,    20.0152339187,     2.4481074113,     1.2916668580,    5, E1/2♭
   2,    20.6017250395,     2.5198424340,     1.3333335247,    6, E♮
   3,    21.8267673594,     2.6696800624,     1.4166668580,    7, F
   4,    23.1246544865,     2.8284274999,     1.5000001913,    8, F♯
   5,    24.4997179983,     2.9966145512,     1.5833335247,    9, G
   6,    25.9565470414,     3.1748025250,     1.6666668580,   10, A♭
   7,    26.7171319252,     3.2678313399,     1.7083335247,   11, A1/2♭
   8,    27.5000036473,     3.3635861071,     1.7500001913,   12, A
   9,    29.1352389591,     3.5635953452,     1.8333335247,   13, B♭
  10,    29.9889666257,     3.6680166593,     1.8750001913,   14, B1/2♭
  11,    30.8677104225,     3.7754977515,     1.9166668580,   15, B♮/C♭
  12,    32.7032000000,     4.0000005305,     2.0000001913,    0, C
  13,    34.6478334675,     4.2378529395,     2.0833335247,    1, D♭/C♯
  14,    35.6630924829,     4.3620315092,     2.1250001913,    2, D1/2♭
  15,    36.7081008583,     4.4898487887,     2.1666668580,    3, D
  16,    38.8908781234,     4.7568290909,     2.2500001913,    4, E♭/D♯
  17,    40.0304678374,     4.8962148226,     2.2916668580,    5, E1/2♭
[..]
```
